### PR TITLE
Avoid calling map.begin() when map is empty

### DIFF
--- a/src/libtsduck/tsPCRAnalyzer.cpp
+++ b/src/libtsduck/tsPCRAnalyzer.cpp
@@ -395,14 +395,16 @@ bool ts::PCRAnalyzer::feedPacket(const TSPacket& pkt)
 
             // Transport stream instantaneous statistics.
             // For instantaneous bit rates, these are the actual bit rates, and it doesn't use the "count" approach.
-            diff_values = _use_dts ?
-                DiffPTS(_packet_pcr_index_map.begin()->first, pcr_dts) * SYSTEM_CLOCK_SUBFACTOR :
-                DiffPCR(_packet_pcr_index_map.begin()->first, pcr_dts);
-            _inst_ts_bitrate_188 = diff_values == 0 ? 0 :
-                ((_ts_pkt_cnt - _packet_pcr_index_map.begin()->second) * SYSTEM_CLOCK_FREQ * PKT_SIZE * 8) / diff_values;
-            _inst_ts_bitrate_204 = diff_values == 0 ? 0 :
-                ((_ts_pkt_cnt - _packet_pcr_index_map.begin()->second) * SYSTEM_CLOCK_FREQ * PKT_RS_SIZE * 8) / diff_values;
-
+            if (!_packet_pcr_index_map.empty()) {
+                diff_values = _use_dts ?
+                    DiffPTS(_packet_pcr_index_map.begin()->first, pcr_dts) * SYSTEM_CLOCK_SUBFACTOR :
+                    DiffPCR(_packet_pcr_index_map.begin()->first, pcr_dts);
+                _inst_ts_bitrate_188 = diff_values == 0 ? 0 :
+                    ((_ts_pkt_cnt - _packet_pcr_index_map.begin()->second) * SYSTEM_CLOCK_FREQ * PKT_SIZE * 8) / diff_values;
+                _inst_ts_bitrate_204 = diff_values == 0 ? 0 :
+                    ((_ts_pkt_cnt - _packet_pcr_index_map.begin()->second) * SYSTEM_CLOCK_FREQ * PKT_RS_SIZE * 8) / diff_values;
+            }
+            
             // Check if we got enough values for this PID
             if (ps->ts_bitrate_cnt == _min_pcr) {
                 _completed_pids++;


### PR DESCRIPTION
Ensure that _packet_pcr_index_map.begin() does not get called when _packet_pcr_index_map is empty.