### PR TITLE
Bugfix: section_syntax_indicator must be ignored for Stuffing Table

### DIFF
--- a/src/libtsduck/tsSection.h
+++ b/src/libtsduck/tsSection.h
@@ -309,7 +309,11 @@ namespace ts {
         //!
         bool isLongSection() const
         {
-            return _is_valid ? ((*_data)[1] & 0x80) != 0 : false;
+            if (_is_valid) {
+                return (((*_data)[1] & 0x80) != 0) && tableId() != TID_ST;
+            }
+
+            return false;
         }
 
         //!

--- a/src/libtsduck/tsSectionDemux.cpp
+++ b/src/libtsduck/tsSectionDemux.cpp
@@ -390,7 +390,7 @@ void ts::SectionDemux::processPacket(const TSPacket& pkt)
         bool section_ok = true;
         ETID etid(ts_start[0]);
         uint16_t section_length = GetUInt16(ts_start + 1);
-        bool long_header = (section_length & 0x8000) != 0;
+        bool long_header = ((section_length & 0x8000) != 0) && etid.tid != TID_ST;
         section_length = (section_length & 0x0FFF) + SHORT_SECTION_HEADER_SIZE;
 
         // Lose synchronization when invalid section length.


### PR DESCRIPTION
**The stuffing table uses a short header but allows arbitrary values for the section_syntax_indicator:**
                           

    


   
![image](https://user-images.githubusercontent.com/51595645/63667315-9b5b7580-c7d3-11e9-9c5c-8f086e23ed2d.png)
